### PR TITLE
Fix/inject mcp config subprocess

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A Model Context Protocol (MCP) server that integrates GitHub Copilot CLI with MC
 - **9 Tools** - Interactive Copilot commands for coding assistance
 - **2 Resources** - Session history and management
 - **3 Prompts** - Workflow templates for common tasks
-- **Full MCP Support** - Compatible with Claude Desktop, Claude Code, Cline, and more
+- **Full MCP Support** - Compatible with Claude Desktop, Claude Code, Codex, Cline, and more
 
 ## Quick Start
 
@@ -172,6 +172,35 @@ claude mcp list
 **Usage in Chat:**
 ```bash
 /mcp  # Check server status
+```
+
+---
+
+### 🤖 Codex CLI
+
+Codex CLI supports MCP via a simple command.
+
+**Quick Setup (npx):**
+```bash
+codex mcp add copilot -- npx -y @leonardommello/copilot-mcp-server
+```
+
+**Use your fork (GitHub npx):**
+```bash
+codex mcp add copilot -- npx -y github:YOUR_USERNAME/copilot-mcp-tool
+```
+
+**Local Development:**
+```bash
+# Build first
+npm run build
+
+codex mcp add copilot -- node "/absolute/path/to/copilot-mcp-tool/dist/esm/examples/server/copilotMcpServer.js"
+```
+
+**Verify Connection:**
+```bash
+codex mcp list
 ```
 
 ---
@@ -336,6 +365,7 @@ This server is compatible with **any MCP-compliant client**. Generic configurati
 **Additional Compatible Clients:**
 - **Amp** - Configuration in `~/.amp/mcp.json`
 - **Augment Code** - MCP settings in IDE
+- **Codex CLI** - CLI: `codex mcp add copilot`
 - **Roo Code** - Via settings panel
 - **Qwen Coder** - CLI: `qwen mcp add copilot`
 
@@ -347,6 +377,7 @@ This server is compatible with **any MCP-compliant client**. Generic configurati
 |--------|--------|-------------------|-------|
 | [Claude Desktop](https://claude.ai/download) | ✅ **Tested** | JSON config | Most stable, recommended |
 | [Claude Code](https://docs.claude.com/en/docs/claude-code) | ✅ **Tested** | CLI command | Fastest setup |
+| [Codex CLI](https://developers.openai.com/codex/cli) | ✅ **Tested** | CLI command | Works with stdio MCP servers |
 | [Cursor](https://cursor.sh/) | ✅ Compatible | JSON / UI | Multiple setup options |
 | [Cline (VS Code)](https://github.com/cline/cline) | ✅ Compatible | Extension settings | VS Code integration |
 | [Zed](https://zed.dev/) | ✅ Compatible | Native MCP support | Built-in UI |

--- a/README.md
+++ b/README.md
@@ -737,6 +737,7 @@ Environment variables for defaults and logging:
 
 - `COPILOT_MODEL`: default model identifier
 - `COPILOT_TIMEOUT`: timeout in milliseconds (default: 60000)
+- `COPILOT_MAX_PROMPT_BYTES`: maximum prompt size passed to `copilot --prompt` (default: 24000, set `0` to disable)
 - `COPILOT_ALLOW_ALL_TOOLS`: default allow-all-tools policy (`true` or `false`)
 - `COPILOT_LOG_FILE`: write JSON line logs to this file path
 - `COPILOT_LOG_LEVEL`: `debug`, `info`, `warn`, or `error` (default: `info`)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ copilot /login
 | **ask-copilot** | Ask Copilot for coding help, debugging, architecture | `prompt`, `context`, `model`, `allowAllTools` |
 | **copilot-explain** | Get detailed code explanations | `code`, `model` |
 | **copilot-suggest** | Get CLI command suggestions | `task`, `model` |
+| **copilot-list-models** | List available Copilot CLI models | - |
 | **copilot-debug** | Debug code errors | `code`, `error`, `context` |
 | **copilot-refactor** | Get refactoring suggestions | `code`, `goal` |
 | **copilot-test-generate** | Generate unit tests | `code`, `framework` |
@@ -569,6 +570,13 @@ const memoize = fn => {
 🤖 Linux: find . -name "*.ts" -mtime -7
 ```
 
+### copilot-list-models
+**Available Copilot model identifiers**
+
+```
+Use copilot-list-models to list available Copilot CLI models
+```
+
 ### copilot-debug
 **Bug identification and fixes**
 
@@ -660,6 +668,11 @@ Use copilot-debug with code="function sum(arr) { return arr.reduce((a) => a+b, 0
 Use copilot-test-generate with code="function isPrime(n) { return n > 1 && ![...Array(n).keys()].slice(2).some(i => n % i === 0); }" and framework="jest"
 ```
 
+**List Models:**
+```
+Use copilot-list-models to list available Copilot CLI models
+```
+
 **Review Code:**
 ```
 Use copilot-review with code="..." and focusAreas=["security", "performance"]
@@ -675,11 +688,8 @@ Use copilot-session-history to view conversation history
 
 ## AI Models
 
-Select from available models:
-- `claude-sonnet-4.5` (default)
-- `claude-sonnet-4`
-- `claude-haiku-4.5`
-- `gpt-5`
+Use `copilot-list-models` to see the latest models available from your Copilot CLI installation.
+If `COPILOT_MODEL` is set, that model is used by default.
 
 Example:
 ```
@@ -687,6 +697,17 @@ Use ask-copilot with model="gpt-5" and prompt="Explain async/await"
 ```
 
 ---
+
+## Configuration
+
+Environment variables for defaults and logging:
+
+- `COPILOT_MODEL`: default model identifier
+- `COPILOT_TIMEOUT`: timeout in milliseconds (default: 60000)
+- `COPILOT_ALLOW_ALL_TOOLS`: default allow-all-tools policy (`true` or `false`)
+- `COPILOT_LOG_FILE`: write JSON line logs to this file path
+- `COPILOT_LOG_LEVEL`: `debug`, `info`, `warn`, or `error` (default: `info`)
+- `COPILOT_DEBUG`: enable stderr debug logs (`true` or `false`)
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ codex mcp add copilot -- npx -y @leonardommello/copilot-mcp-server
 ```bash
 codex mcp add copilot -- npx -y github:YOUR_USERNAME/copilot-mcp-tool
 ```
+Note: `npx -y @YOUR_USERNAME/copilot-mcp-tool` only works if you published to npm. For GitHub forks, use the `github:` form. If needed, append the bin name: `... github:YOUR_USERNAME/copilot-mcp-tool copilot-mcp-server`.
 
 **Local Development:**
 ```bash
@@ -223,6 +224,7 @@ Edit `~/.cursor/mcp.json` (create if it doesn't exist):
   }
 }
 ```
+For forks, replace the package with `github:YOUR_USERNAME/copilot-mcp-tool` in the args array.
 
 **Method 2: Settings UI**
 1. Open Cursor Settings (Cmd/Ctrl + ,)

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "build": "npm run build:esm && npm run build:cjs",
         "build:esm": "node scripts/prepare-esm.js && tsc -p tsconfig.prod.json",
         "build:cjs": "node scripts/prepare-cjs.js && tsc -p tsconfig.cjs.json",
+        "prepare": "npm run build",
         "prepack": "npm run build",
         "prepublishOnly": "npm run build",
         "start": "node dist/esm/examples/server/copilotMcpServer.js",

--- a/src/examples/server/copilotMcpServer.ts
+++ b/src/examples/server/copilotMcpServer.ts
@@ -174,7 +174,6 @@ async function initDirectories() {
 async function checkCopilotInstalled(): Promise<boolean> {
     return new Promise(resolve => {
         const child = spawn(COPILOT_COMMAND, ['--version'], {
-            shell: true,
             stdio: 'pipe'
         });
 
@@ -191,7 +190,6 @@ async function checkCopilotInstalled(): Promise<boolean> {
 async function getCopilotHelpOutput(): Promise<string> {
     return new Promise((resolve, reject) => {
         const child = spawn(COPILOT_COMMAND, ['--help'], {
-            shell: true,
             stdio: ['ignore', 'pipe', 'pipe']
         });
 
@@ -378,7 +376,6 @@ async function executeCopilotCommand(
         }
 
         const child = spawn(COPILOT_COMMAND, args, {
-            shell: true,
             stdio: ['ignore', 'pipe', 'pipe']
         });
 

--- a/src/examples/server/copilotMcpServer.ts
+++ b/src/examples/server/copilotMcpServer.ts
@@ -21,6 +21,63 @@ import { homedir } from 'os';
 import { join } from 'path';
 
 const COPILOT_COMMAND = 'copilot';
+const DEFAULT_TIMEOUT_MS = 60000;
+const HELP_TIMEOUT_MS = 5000;
+const FALLBACK_MODELS = [
+    'claude-sonnet-4.5',
+    'claude-haiku-4.5',
+    'claude-opus-4.5',
+    'claude-sonnet-4',
+    'gpt-5.2-codex',
+    'gpt-5.1-codex-max',
+    'gpt-5.1-codex',
+    'gpt-5.2',
+    'gpt-5.1',
+    'gpt-5',
+    'gpt-5.1-codex-mini',
+    'gpt-5-mini',
+    'gpt-4.1',
+    'gemini-3-pro-preview'
+];
+const MODEL_TOKEN_REGEX = /\b(?:claude|gpt|gemini|o)[a-z0-9.-]*\b/gi;
+
+function parseBoolean(value: string | undefined): boolean | undefined {
+    if (!value) {
+        return undefined;
+    }
+
+    const normalized = value.trim().toLowerCase();
+    if (['true', '1', 'yes', 'y', 'on'].includes(normalized)) {
+        return true;
+    }
+    if (['false', '0', 'no', 'n', 'off'].includes(normalized)) {
+        return false;
+    }
+    return undefined;
+}
+
+function getDefaultModel(): string | undefined {
+    const model = process.env.COPILOT_MODEL?.trim();
+    return model ? model : undefined;
+}
+
+function getAllowAllToolsDefault(): boolean {
+    return parseBoolean(process.env.COPILOT_ALLOW_ALL_TOOLS) ?? false;
+}
+
+function getTimeoutMs(): number {
+    const timeoutValue = process.env.COPILOT_TIMEOUT;
+    if (!timeoutValue) {
+        return DEFAULT_TIMEOUT_MS;
+    }
+
+    const parsed = Number.parseInt(timeoutValue, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+        return parsed;
+    }
+
+    return DEFAULT_TIMEOUT_MS;
+}
 
 // Session management
 interface CopilotSession {
@@ -71,6 +128,95 @@ async function checkCopilotInstalled(): Promise<boolean> {
     });
 }
 
+async function getCopilotHelpOutput(): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const child = spawn(COPILOT_COMMAND, ['--help'], {
+            shell: true,
+            stdio: ['ignore', 'pipe', 'pipe']
+        });
+
+        let stdout = '';
+        let stderr = '';
+        let settled = false;
+
+        const finish = (fn: () => void) => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            fn();
+        };
+
+        const clearTimeoutId = () => {
+            if (timeoutId) {
+                clearTimeout(timeoutId);
+            }
+        };
+
+        child.stdout.on('data', data => {
+            stdout += data.toString();
+        });
+
+        child.stderr.on('data', data => {
+            stderr += data.toString();
+        });
+
+        child.on('error', error => {
+            clearTimeoutId();
+            finish(() => reject(new Error(`Failed to execute copilot --help: ${error.message}`)));
+        });
+
+        child.on('exit', () => {
+            clearTimeoutId();
+            const output = stdout.trim() || stderr.trim();
+            if (!output) {
+                finish(() => reject(new Error('No output from copilot --help')));
+                return;
+            }
+            finish(() => resolve(output));
+        });
+
+        const timeoutId = setTimeout(() => {
+            child.kill();
+            finish(() => reject(new Error('Copilot CLI help command timed out')));
+        }, HELP_TIMEOUT_MS);
+    });
+}
+
+function parseModelsFromHelpOutput(helpText: string): string[] {
+    const matches = helpText.match(MODEL_TOKEN_REGEX) ?? [];
+    const seen = new Set<string>();
+    const models: string[] = [];
+
+    for (const match of matches) {
+        const token = match.toLowerCase();
+        if (!/\d/.test(token)) {
+            continue;
+        }
+        if (seen.has(token)) {
+            continue;
+        }
+        seen.add(token);
+        models.push(token);
+    }
+
+    return models;
+}
+
+async function listCopilotModels(): Promise<{ models: string[]; source: 'help' | 'fallback' }> {
+    try {
+        const helpOutput = await getCopilotHelpOutput();
+        const parsed = parseModelsFromHelpOutput(helpOutput);
+        if (parsed.length > 0) {
+            return { models: parsed, source: 'help' };
+        }
+    } catch (error) {
+        console.error(`Warning: Failed to parse copilot --help: ${error instanceof Error ? error.message : String(error)}`);
+    }
+
+    return { models: FALLBACK_MODELS, source: 'fallback' };
+}
+
 // Execute Copilot CLI command with options
 async function executeCopilotCommand(
     prompt: string,
@@ -84,16 +230,19 @@ async function executeCopilotCommand(
 ): Promise<string> {
     return new Promise((resolve, reject) => {
         const fullPrompt = options.context ? `${prompt}\n\nContext:\n${options.context}` : prompt;
+        const selectedModel = options.model ?? getDefaultModel();
+        const allowAllTools = options.allowAllTools ?? getAllowAllToolsDefault();
+        const timeoutMs = getTimeoutMs();
 
         const args: string[] = ['--prompt', fullPrompt, '--silent'];
 
         // Add model selection
-        if (options.model) {
-            args.push('--model', options.model);
+        if (selectedModel) {
+            args.push('--model', selectedModel);
         }
 
         // Add tool permissions
-        if (options.allowAllTools) {
+        if (allowAllTools) {
             args.push('--allow-all-tools');
         }
 
@@ -116,7 +265,6 @@ async function executeCopilotCommand(
         let stderr = '';
         let hasReceivedOutput = false;
         let settled = false;
-        let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
         const finish = (fn: () => void) => {
             if (settled) {
@@ -173,7 +321,7 @@ async function executeCopilotCommand(
         });
 
         // Timeout after 60 seconds
-        timeoutId = setTimeout(() => {
+        const timeoutId = setTimeout(() => {
             child.kill();
 
             if (hasReceivedOutput) {
@@ -181,7 +329,7 @@ async function executeCopilotCommand(
             } else {
                 finish(() => reject(new Error('Copilot CLI command timed out with no response')));
             }
-        }, 60000);
+        }, timeoutMs);
     });
 }
 
@@ -307,7 +455,42 @@ server.registerTool(
     }
 );
 
-// 4. Debug Code
+// 4. List Models
+server.registerTool(
+    'copilot-list-models',
+    {
+        title: 'List Copilot Models',
+        description: 'List available GitHub Copilot CLI model identifiers',
+        inputSchema: {}
+    },
+    async (): Promise<CallToolResult> => {
+        try {
+            const isInstalled = await checkCopilotInstalled();
+            if (!isInstalled) {
+                return {
+                    content: [{ type: 'text', text: 'Error: GitHub Copilot CLI is not installed.' }],
+                    isError: true
+                };
+            }
+
+            const { models, source } = await listCopilotModels();
+            const header = source === 'help'
+                ? 'Available Copilot models (from copilot --help):'
+                : 'Available Copilot models (fallback list):';
+            const body = models.map(model => `- ${model}`).join('\n');
+            const text = `${header}\n${body}`;
+
+            return { content: [{ type: 'text', text }] };
+        } catch (error) {
+            return {
+                content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+                isError: true
+            };
+        }
+    }
+);
+
+// 5. Debug Code
 server.registerTool(
     'copilot-debug',
     {
@@ -341,7 +524,7 @@ server.registerTool(
     }
 );
 
-// 5. Refactor Code
+// 6. Refactor Code
 server.registerTool(
     'copilot-refactor',
     {
@@ -376,7 +559,7 @@ server.registerTool(
     }
 );
 
-// 6. Generate Tests
+// 7. Generate Tests
 server.registerTool(
     'copilot-test-generate',
     {
@@ -411,7 +594,7 @@ server.registerTool(
     }
 );
 
-// 7. Review Code
+// 8. Review Code
 server.registerTool(
     'copilot-review',
     {
@@ -446,7 +629,7 @@ server.registerTool(
     }
 );
 
-// 8. Session Management
+// 9. Session Management
 server.registerTool(
     'copilot-session-start',
     {
@@ -686,7 +869,7 @@ async function main() {
 
     console.error('✅ Server running on stdio');
     console.error('📦 Features enabled:');
-    console.error('   - 8 Tools (ask, explain, suggest, debug, refactor, test, review, session)');
+    console.error('   - 9 Tools (ask, explain, suggest, list-models, debug, refactor, test, review, session)');
     console.error('   - 2 Resources (session history, sessions list)');
     console.error('   - 3 Prompts (code review, debug, refactor templates)');
     console.error('Waiting for requests...\n');

--- a/src/examples/server/copilotMcpServer.ts
+++ b/src/examples/server/copilotMcpServer.ts
@@ -16,7 +16,7 @@ import { McpServer, ResourceTemplate } from '../../server/mcp.js';
 import { StdioServerTransport } from '../../server/stdio.js';
 import { CallToolResult } from '../../types.js';
 import { appendFile, mkdir } from 'fs/promises';
-import { existsSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
 
@@ -365,6 +365,15 @@ async function executeCopilotCommand(
         additionalArgs?: string[];
     } = {}
 ): Promise<CopilotCommandResult> {
+    // Read MCP config before the Promise — await is not valid inside a Promise callback.
+    // Path defaults to ~/.copilot/mcp-config.json, override with COPILOT_MCP_CONFIG_PATH.
+    let mcpConfig: string | undefined;
+    const mcpConfigPath = process.env.COPILOT_MCP_CONFIG_PATH?.trim()
+        || join(homedir(), '.copilot', 'mcp-config.json');
+    try {
+        mcpConfig = readFileSync(mcpConfigPath, 'utf-8').trim();
+    } catch (e) { /* no mcp config found, skip */ }
+
     return new Promise((resolve, reject) => {
         const fullPrompt = options.context ? `${prompt}\n\nContext:\n${options.context}` : prompt;
         const selectedModel = options.model ?? getDefaultModel();
@@ -408,6 +417,14 @@ async function executeCopilotCommand(
         // Add additional arguments
         if (options.additionalArgs) {
             args.push(...options.additionalArgs);
+        }
+
+        // Inject user MCP config so subprocess has access to all registered MCP tools.
+        // COPILOT_MCP_CONFIG_PATH overrides the default ~/.copilot/mcp-config.json path.
+        // Note: requires shell: false (default in this file) — shell: true would cause
+        // the JSON to be interpreted by /bin/sh, breaking the argument entirely.
+        if (mcpConfig) {
+            args.push('--additional-mcp-config', mcpConfig);
         }
 
         const child = spawn(COPILOT_COMMAND, args, {

--- a/src/examples/server/copilotMcpServer.ts
+++ b/src/examples/server/copilotMcpServer.ts
@@ -43,13 +43,39 @@ const initMcpConfigDir = (): void => {
     const mcpConfigPath = process.env.COPILOT_MCP_CONFIG_PATH?.trim()
         || join(homedir(), '.copilot', 'mcp-config.json');
     try {
-        const mcpConfig = readFileSync(mcpConfigPath, 'utf-8');
+        const raw = JSON.parse(readFileSync(mcpConfigPath, 'utf-8')) as {
+            mcpServers: Record<string, unknown>;
+        };
+
+        // Filter servers: COPILOT_MCP_INCLUDE_SERVERS (whitelist) takes priority,
+        // then COPILOT_MCP_EXCLUDE_SERVERS (blacklist), then inject all if neither set.
+        const includeEnv = process.env.COPILOT_MCP_INCLUDE_SERVERS?.trim();
+        const excludeEnv = process.env.COPILOT_MCP_EXCLUDE_SERVERS?.trim();
+        let servers = raw.mcpServers ?? {};
+
+        if (includeEnv) {
+            const include = new Set(includeEnv.split(',').map(s => s.trim()));
+            servers = Object.fromEntries(
+                Object.entries(servers).filter(([k]) => include.has(k))
+            );
+        } else if (excludeEnv) {
+            const exclude = new Set(excludeEnv.split(',').map(s => s.trim()));
+            servers = Object.fromEntries(
+                Object.entries(servers).filter(([k]) => !exclude.has(k))
+            );
+        }
+
+        const filtered = JSON.stringify({ mcpServers: servers });
         const tmpDir = mkdtempSync(join(homedir(), '.copilot', 'mcp-tmp-'));
         chmodSync(tmpDir, 0o700);
-        writeFileSync(join(tmpDir, 'mcp-config.json'), mcpConfig, { mode: 0o600 });
+        writeFileSync(join(tmpDir, 'mcp-config.json'), filtered, { mode: 0o600 });
         mcpTmpDirs.add(tmpDir);
         cachedMcpConfigDir = tmpDir;
-        logMessage('debug', 'MCP config loaded', { path: mcpConfigPath, tmpDir });
+        logMessage('debug', 'MCP config loaded', {
+            path: mcpConfigPath,
+            tmpDir,
+            servers: Object.keys(servers)
+        });
     } catch (e) {
         logMessage('debug', 'No MCP config found or failed to load', {
             path: mcpConfigPath,

--- a/src/examples/server/copilotMcpServer.ts
+++ b/src/examples/server/copilotMcpServer.ts
@@ -39,6 +39,9 @@ process.on('SIGTERM', () => { cleanupMcpTmpDirs(); process.exit(143); });
 
 // Cache MCP config at startup to avoid repeated synchronous disk I/O per call
 let cachedMcpConfigDir: string | undefined;
+// Servers to disable via --disable-mcp-server (those filtered out from the default config)
+let cachedDisabledServers: string[] = [];
+
 const initMcpConfigDir = (): void => {
     const mcpConfigPath = process.env.COPILOT_MCP_CONFIG_PATH?.trim()
         || join(homedir(), '.copilot', 'mcp-config.json');
@@ -51,19 +54,26 @@ const initMcpConfigDir = (): void => {
         // then COPILOT_MCP_EXCLUDE_SERVERS (blacklist), then inject all if neither set.
         const includeEnv = process.env.COPILOT_MCP_INCLUDE_SERVERS?.trim();
         const excludeEnv = process.env.COPILOT_MCP_EXCLUDE_SERVERS?.trim();
-        let servers = raw.mcpServers ?? {};
+        const allServers = raw.mcpServers ?? {};
+        let servers = allServers;
 
         if (includeEnv) {
             const include = new Set(includeEnv.split(',').map(s => s.trim()));
             servers = Object.fromEntries(
-                Object.entries(servers).filter(([k]) => include.has(k))
+                Object.entries(allServers).filter(([k]) => include.has(k))
             );
         } else if (excludeEnv) {
             const exclude = new Set(excludeEnv.split(',').map(s => s.trim()));
             servers = Object.fromEntries(
-                Object.entries(servers).filter(([k]) => !exclude.has(k))
+                Object.entries(allServers).filter(([k]) => !exclude.has(k))
             );
         }
+
+        // Build the list of servers to explicitly disable via --disable-mcp-server.
+        // The copilot CLI loads BOTH ~/.copilot/mcp-config.json and --config-dir/mcp-config.json,
+        // so filtered-out servers must also be disabled via this flag.
+        const allowedKeys = new Set(Object.keys(servers));
+        cachedDisabledServers = Object.keys(allServers).filter(k => !allowedKeys.has(k));
 
         const filtered = JSON.stringify({ mcpServers: servers });
         const tmpDir = mkdtempSync(join(homedir(), '.copilot', 'mcp-tmp-'));
@@ -74,7 +84,8 @@ const initMcpConfigDir = (): void => {
         logMessage('debug', 'MCP config loaded', {
             path: mcpConfigPath,
             tmpDir,
-            servers: Object.keys(servers)
+            servers: Object.keys(servers),
+            disabled: cachedDisabledServers
         });
     } catch (e) {
         logMessage('debug', 'No MCP config found or failed to load', {
@@ -474,6 +485,13 @@ async function executeCopilotCommand(
         // The temp dir is created once at startup and cleaned up on process exit.
         if (cachedMcpConfigDir) {
             args.push('--config-dir', cachedMcpConfigDir);
+        }
+
+        // Explicitly disable servers that were filtered out from the default config.
+        // The copilot CLI loads BOTH ~/.copilot/mcp-config.json and --config-dir/mcp-config.json,
+        // so filtered-out servers must also be disabled to prevent invalid schemas reaching the API.
+        for (const name of cachedDisabledServers) {
+            args.push('--disable-mcp-server', name);
         }
 
         const child = spawn(COPILOT_COMMAND, args, {

--- a/src/examples/server/copilotMcpServer.ts
+++ b/src/examples/server/copilotMcpServer.ts
@@ -16,7 +16,7 @@ import { McpServer, ResourceTemplate } from '../../server/mcp.js';
 import { StdioServerTransport } from '../../server/stdio.js';
 import { CallToolResult } from '../../types.js';
 import { appendFile, mkdir } from 'fs/promises';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdtempSync, rmSync, chmodSync } from 'fs';
 import { homedir } from 'os';
 import { join } from 'path';
 
@@ -24,6 +24,39 @@ const COPILOT_COMMAND = 'copilot';
 const DEFAULT_TIMEOUT_MS = 60000;
 const HELP_TIMEOUT_MS = 5000;
 const DEFAULT_MAX_PROMPT_BYTES = 24000;
+
+// Track temp dirs created for MCP config injection so we can clean up on exit
+const mcpTmpDirs = new Set<string>();
+const cleanupMcpTmpDirs = (): void => {
+    for (const dir of mcpTmpDirs) {
+        try { rmSync(dir, { recursive: true, force: true }); } catch (_) {}
+    }
+    mcpTmpDirs.clear();
+};
+process.on('exit', cleanupMcpTmpDirs);
+process.on('SIGINT', () => { cleanupMcpTmpDirs(); process.exit(130); });
+process.on('SIGTERM', () => { cleanupMcpTmpDirs(); process.exit(143); });
+
+// Cache MCP config at startup to avoid repeated synchronous disk I/O per call
+let cachedMcpConfigDir: string | undefined;
+const initMcpConfigDir = (): void => {
+    const mcpConfigPath = process.env.COPILOT_MCP_CONFIG_PATH?.trim()
+        || join(homedir(), '.copilot', 'mcp-config.json');
+    try {
+        const mcpConfig = readFileSync(mcpConfigPath, 'utf-8');
+        const tmpDir = mkdtempSync(join(homedir(), '.copilot', 'mcp-tmp-'));
+        chmodSync(tmpDir, 0o700);
+        writeFileSync(join(tmpDir, 'mcp-config.json'), mcpConfig, { mode: 0o600 });
+        mcpTmpDirs.add(tmpDir);
+        cachedMcpConfigDir = tmpDir;
+        logMessage('debug', 'MCP config loaded', { path: mcpConfigPath, tmpDir });
+    } catch (e) {
+        logMessage('debug', 'No MCP config found or failed to load', {
+            path: mcpConfigPath,
+            error: (e as Error).message
+        });
+    }
+};
 const FALLBACK_MODELS = [
     'claude-sonnet-4.5',
     'claude-haiku-4.5',
@@ -365,15 +398,6 @@ async function executeCopilotCommand(
         additionalArgs?: string[];
     } = {}
 ): Promise<CopilotCommandResult> {
-    // Read MCP config before the Promise — await is not valid inside a Promise callback.
-    // Path defaults to ~/.copilot/mcp-config.json, override with COPILOT_MCP_CONFIG_PATH.
-    let mcpConfig: string | undefined;
-    const mcpConfigPath = process.env.COPILOT_MCP_CONFIG_PATH?.trim()
-        || join(homedir(), '.copilot', 'mcp-config.json');
-    try {
-        mcpConfig = readFileSync(mcpConfigPath, 'utf-8').trim();
-    } catch (e) { /* no mcp config found, skip */ }
-
     return new Promise((resolve, reject) => {
         const fullPrompt = options.context ? `${prompt}\n\nContext:\n${options.context}` : prompt;
         const selectedModel = options.model ?? getDefaultModel();
@@ -419,12 +443,11 @@ async function executeCopilotCommand(
             args.push(...options.additionalArgs);
         }
 
-        // Inject user MCP config so subprocess has access to all registered MCP tools.
-        // COPILOT_MCP_CONFIG_PATH overrides the default ~/.copilot/mcp-config.json path.
-        // Note: requires shell: false (default in this file) — shell: true would cause
-        // the JSON to be interpreted by /bin/sh, breaking the argument entirely.
-        if (mcpConfig) {
-            args.push('--additional-mcp-config', mcpConfig);
+        // Inject user MCP config via a secure temp dir (chmod 700/600).
+        // Using --config-dir avoids exposing secrets in argv (visible via ps/Task Manager).
+        // The temp dir is created once at startup and cleaned up on process exit.
+        if (cachedMcpConfigDir) {
+            args.push('--config-dir', cachedMcpConfigDir);
         }
 
         const child = spawn(COPILOT_COMMAND, args, {
@@ -1050,6 +1073,9 @@ async function main() {
 
     // Initialize directories
     await initDirectories();
+
+    // Load MCP config into a secure temp dir for subprocess injection
+    initMcpConfigDir();
 
     // Create initial session
     createSession();


### PR DESCRIPTION
   When the Copilot CLI runs as a subprocess, it does not inherit the user's ~/.copilot/mcp-config.json, making all registered MCP tools unavailable (aws___search_documentation, brave_search, etc.) with 'Permission denied'.

   - Read mcp-config.json before the Promise (await not valid in callback)
   - Pass it via --additional-mcp-config to give subprocess access to MCP tools
   - COPILOT_MCP_CONFIG_PATH env var to override the default config path

   Note: this fix requires shell: false which is already addressed by PR #6 